### PR TITLE
Bugfix 0005 cim generation

### DIFF
--- a/loader/assets/annotate.py
+++ b/loader/assets/annotate.py
@@ -8,6 +8,7 @@ import ui.log
 def annotate(corePath):
     """Generate an annotated Space Haven library"""
 
+    # NOTE: textures and animations do not seem to get annotated.  Should this be replaced?  I would like to use these to make additional annotations in `haven`.
     texture_names = {}
     local_texture_names = ElementTree.parse("textures_annotations.xml", parser=XMLParser(recover=True))
     for region in local_texture_names.findall(".//re[@n]"):
@@ -29,7 +30,7 @@ def annotate(corePath):
     
     haven = ElementTree.parse(os.path.join(corePath, "library", "haven"), parser=XMLParser(recover=True))
     texts = ElementTree.parse(os.path.join(corePath, "library", "texts"), parser=XMLParser(recover=True))
-        
+
     tids = {}
     # Load texts
     for text in texts.getroot():
@@ -45,12 +46,48 @@ def annotate(corePath):
             return ""
 
         return tids[tid]
-    
+
+
+    ##############################################################################################
+    # Recurse EVERY element in the entire haven file, trying to find the name and set the 
+    # annotation where it's obvious.  This is only a first pass, but covers all of these tags:
+	#	Product/product
+	#	Item/item
+	#	Tech/tech
+	#	GameScenario/game
+	#	SubCat/cat
+	#	PersonalitySettings/attributes/l
+	#	DifficultySettings/settings
+	#	Faction/faction
+	#	Craft/craft
+	#	DataLog/dataLog
+	#	BackStory/backstory
+	#	CharacterTrait/trait
+	#	CharacterCondition/condition
+	#	MainCat/cat
+    # Later, tags that need special treatment will get it.
+    ui.log.log("  Process haven data for names...")
+    # Annotate every XML element where the name is obvious.
+    for e in haven.iter():
+        # giving annotations to these tags would be redundant or spammy.
+        if e.tag in ["name","desc","objectInfo","text"]:
+            continue
+        name = nameOf(e)
+        if name:
+            e.set("_annotation", name)
+
+    # Write the partially annotated haven file, in case something goes wrong later.
+    annotatedHavenPath = os.path.join(corePath, "library", "haven_annotated.xml")
+    haven.write(annotatedHavenPath)
+
+
+    ##############################################################################################
+    # Special treatment begins here.
+    # Annotate Elements and create list of links.
     ui.log.log("  annotate Element...")
     ElementRoot = haven.find("Element")
     ElementName = {}
     ElementLink = {}
-    # Annotate Elements and create list of links.
     for element in ElementRoot:
         mid = element.get("mid")
         objectInfo = element.find("objectInfo")
@@ -79,6 +116,7 @@ def annotate(corePath):
 
     # Annotate basic products
     # first pass also builds the names cache
+    # NOTE: Maybe this can be refactored, since these already have _annotation.
     elementNames = {}
     ProductRoot = haven.find("Product")
     for element in ProductRoot:
@@ -172,6 +210,7 @@ def annotate(corePath):
     
 
 
+    # NOTE: Maybe this can be refactored, since these already have _annotation.
     ui.log.log("  annotate Tech...")
     TechRoot = haven.find("Tech")
     TechName = {}
@@ -199,6 +238,7 @@ def annotate(corePath):
                 techlink.set("_toName", TechName[toId])
 
 
+    # NOTE: Maybe this can be refactored or removed, since these already have _annotation.
     ui.log.log("  annotate MainCat...")
     MainCatRoot = haven.find("MainCat")
     MainCatName = {}

--- a/loader/assets/annotate.py
+++ b/loader/assets/annotate.py
@@ -5,10 +5,13 @@ from lxml.etree import XMLParser
 
 import ui.log
 
+
+
 def annotate(corePath):
     """Generate an annotated Space Haven library"""
 
-    # NOTE: textures and animations do not seem to get annotated.  Should this be replaced?  I would like to use these to make additional annotations in `haven`.
+
+    # NOTE: textures and animations do not seem to get annotated.  Should this be replaced?  WP would like to use these to make additional annotations in `haven`.
     texture_names = {}
     local_texture_names = ElementTree.parse("textures_annotations.xml", parser=XMLParser(recover=True))
     for region in local_texture_names.findall(".//re[@n]"):
@@ -22,7 +25,6 @@ def annotate(corePath):
         if not asset_id in texture_names:
             continue
         assetPos.set('_annotation', texture_names[asset_id])
-
     
     annotatedPath = os.path.join(corePath, "library", "animations_annotated.xml")
     animations.write(annotatedPath)
@@ -187,6 +189,7 @@ def annotate(corePath):
         except:
             pass
     
+    # NOTE: Maybe this can be refactored
     # Annotations for other critial sections.
     ui.log.log("  annotate DifficultySettings...")
     DifficultySettings = haven.find('DifficultySettings')
@@ -250,7 +253,7 @@ def annotate(corePath):
             MainCatName[id] = cat.get("_annotation")
 
 
-
+    # NOTE: maybe refactor to only use the tags for the annotation, as the path is always the same and a bit verbose.
     ui.log.log("  annotate DataLogFragment...")
     # First get gfile names.
     gfiles = ElementTree.parse(os.path.join(corePath, "library", "gfiles"), parser=XMLParser(recover=True))

--- a/loader/assets/merge.py
+++ b/loader/assets/merge.py
@@ -71,6 +71,10 @@ def _detect_textures(coreLibrary, modLibrary, mod):
 
     #FIXME verify that there's only one file
     # TODO Maybe don't require only a single file?
+    textures_count = len(modLibrary['library/textures'])
+    if len(modLibrary['library/textures']) != 1:
+        ui.log.log(f"    Expected 1 library/textures but found {textures_count}")
+
     textures_mod = modLibrary['library/textures'][0]
 
     # Allocate any manually defined texture regions into the CTC lib
@@ -87,6 +91,9 @@ def _detect_textures(coreLibrary, modLibrary, mod):
     if not mapping_n_region and not autoAnimations:
         return modded_textures
 
+    ##########################################################################
+    # Custom Mod Textures processing starts here
+    ##########################################################################
     needs_autogeneration = set()
     for animation_chunk in modLibrary['library/animations']:
         # iterate on autogeneration nodes
@@ -121,9 +128,11 @@ def _detect_textures(coreLibrary, modLibrary, mod):
         regionsNode = textures_mod.find("//regions")
         texturesNode = textures_mod.find("//textures")
         textureID = ui.database.ModDatabase.getMod(mod).prefix
+
         # Catch missing Modder ID.  Still try to process and move forward.
         if not textureID or textureID <= 0:
             ui.log.log("ERROR: info.xml is missing <modid>.  Mod Author should set this to their Discord ID for all mods they make.")
+
         packer = rectpack.newPacker(rotation=False)
         sumA:int = 0  # Total Area
         sumW:int = 0  # Total Width
@@ -316,11 +325,11 @@ def mods(corePath, modPaths):
                 extra_assets.append('library/' + cim_name)
             cims[page] = Texture(os.path.join(corePath, 'library', cim_name), **kwargs)
 
-            reexport_cims[page] = set()
+            #reexport_cims[page] = set()
 
         # BUG #5 : CRASH ON CIM CREATION
         # write back the cim file as png for debugging
-        reexport_cims[page].add(os.path.normpath(mod + "/textures"))
+        #reexport_cims[page].add(os.path.normpath(mod + "/textures"))
 
         x = int(region.get("x"))
         y = int(region.get("y"))
@@ -334,8 +343,7 @@ def mods(corePath, modPaths):
     for page in cims:
         ui.log.log("  Writing {}.cim...".format(page))
         cims[page].export_cim(os.path.join(corePath, 'library', '{}.cim'.format(page)))
-        for path in reexport_cims[page]:
-            cims[page].export_png(os.path.join(path, 'modded_cim_{}.png'.format(page)))
+
 
     return extra_assets
 


### PR DESCRIPTION
Work in progress.
The bug in question is prevented simply by commenting out the offending code, but this means we no longer export the packed texture at all.
Some other potential bugs are now being prevented or being logged now.
We should probably start requiring mods to set the modid in info.xml and throw a warning if it is missing, starting on version 0.10.0

TODO: re-implement re-exporting the merged patched texture files by moving it to the end of the entire process, when the new JAR is created.  Perhaps this should have a checkbox on the UI.