### PR TITLE
Wolfs linux support fix

### DIFF
--- a/spacehaven-modloader.py
+++ b/spacehaven-modloader.py
@@ -9,7 +9,7 @@ import traceback
 try:
     import winreg
 except (ImportError, ModuleNotFoundError):
-    print (winreg was not loaded in)
+    print ("winreg was not loaded in")
     #winreg is None
 
 from collections import OrderedDict
@@ -19,7 +19,7 @@ from tkinter import filedialog, messagebox
 try:
     from steamfiles import acf
 except (ImportError, ModuleNotFoundError):
-    print (steamfiles acf was not loaded in)
+    print ("steamfiles acf was not loaded in")
 
 import loader.extract
 import loader.load

--- a/spacehaven-modloader.py
+++ b/spacehaven-modloader.py
@@ -259,12 +259,12 @@ class Window(Frame):
             filetypes.append(('spacehaven.app', '*.app'))
         elif platform.system() == "Linux":
             filetypes.append(('all files', '*'))
-            # here someone needs to check if the given path is a executalble fiel!
-            # i suggest >os.system("bash -c \"file spacehaven\"")<
+            # here someone needs to check if the given path is a executable file!
+            # I suggest >os.system("bash -c \"file spacehaven\"")< or > with open('spacehaven', mode='rb', buffering=8, encoding=None) as f: f.read(8) compare to ELF magic<
             # the output should be something like 'spacehaven: ELF 64-bit LSB executable,
             # \ x86-64, version 1 (GNU/Linux), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2,
             # \ for GNU/Linux 2.6.32, BuildID[sha1]=b66a5b80c86e626aa41006e4719afcf199a483d6,
-            # \ with debug_info, not stripped' <--- obviously the some variables can change!
+            # \ with debug_info, not stripped' <--- obviously some variables can change!
 
         self.locateSpacehaven(
             filedialog.askopenfilename(

--- a/spacehaven-modloader.py
+++ b/spacehaven-modloader.py
@@ -5,15 +5,21 @@ import platform
 import subprocess
 import threading
 import traceback
+
 try:
     import winreg
 except (ImportError, ModuleNotFoundError):
-    winreg is None
+    print (winreg was not loaded in)
+    #winreg is None
+
 from collections import OrderedDict
 from tkinter import *
 from tkinter import filedialog, messagebox
 
-from steamfiles import acf
+try:
+    from steamfiles import acf
+except (ImportError, ModuleNotFoundError):
+    print (steamfiles acf was not loaded in)
 
 import loader.extract
 import loader.load

--- a/spacehaven-modloader.py
+++ b/spacehaven-modloader.py
@@ -8,19 +8,13 @@ import traceback
 
 try:
     import winreg
+    from steamfiles import acf
 except (ImportError, ModuleNotFoundError):
-    print ("winreg was not loaded in")
-    #winreg is None
+    winreg = None
 
 from collections import OrderedDict
 from tkinter import *
 from tkinter import filedialog, messagebox
-
-try:
-    from steamfiles import acf
-except (ImportError, ModuleNotFoundError):
-    print ("steamfiles acf was not loaded in")
-
 import loader.extract
 import loader.load
 import ui.database
@@ -50,6 +44,7 @@ POSSIBLE_SPACEHAVEN_LOCATIONS = [
     "../../SpaceHaven/spacehaven",
     "~/Games/SpaceHaven/spacehaven",
     ".local/share/Steam/steamapps/common/SpaceHaven/spacehaven",
+    "../Space Haven/game/spacehaven.jar",
 ]
 DatabaseHandler = ui.database.ModDatabase
 

--- a/spacehaven-modloader.py
+++ b/spacehaven-modloader.py
@@ -377,7 +377,7 @@ class Window(Frame):
     can_quit = True
     def disable_UI(self, message):
         self.set_ui_state(DISABLED, message)
-        self.config(cursor = 'wait')
+        self.config(cursor = '')
         self.can_quit = False
     
     def enable_UI(self, message):

--- a/spacehaven-modloader.py
+++ b/spacehaven-modloader.py
@@ -44,7 +44,7 @@ POSSIBLE_SPACEHAVEN_LOCATIONS = [
     "../../SpaceHaven/spacehaven",
     "~/Games/SpaceHaven/spacehaven",
     ".local/share/Steam/steamapps/common/SpaceHaven/spacehaven",
-    "../Space Haven/game/spacehaven.jar",
+    "../Space Haven/game/spacehaven",
 ]
 DatabaseHandler = ui.database.ModDatabase
 
@@ -259,7 +259,13 @@ class Window(Frame):
             filetypes.append(('spacehaven.app', '*.app'))
         elif platform.system() == "Linux":
             filetypes.append(('all files', '*'))
-        
+            # here someone needs to check if the given path is a executalble fiel!
+            # i suggest >os.system("bash -c \"file spacehaven\"")<
+            # the output should be something like 'spacehaven: ELF 64-bit LSB executable,
+            # \ x86-64, version 1 (GNU/Linux), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2,
+            # \ for GNU/Linux 2.6.32, BuildID[sha1]=b66a5b80c86e626aa41006e4719afcf199a483d6,
+            # \ with debug_info, not stripped' <--- obviously the some variables can change!
+
         self.locateSpacehaven(
             filedialog.askopenfilename(
                 parent=self.master,


### PR DESCRIPTION
- Changed the exception handling for winreg and added the steam module that only is not needed in the recognition on linux. 
- added a path to the game when you have the gog.com version of the game.
- added a suggestion for a validation of the linux executable.
- changed a cursor that led to a crash under linux.

[Protocol.txt](https://github.com/Tahvohck/spacehaven-modloader/files/6214312/Protocol.txt)
This file contains a .md file of my adventures.